### PR TITLE
convert opsgenie sns resources from count to for_each due to tf bug

### DIFF
--- a/opsgenie/outputs.tf
+++ b/opsgenie/outputs.tf
@@ -1,4 +1,7 @@
 output "team_sns_topics" {
-  value = zipmap(keys(var.teams), aws_sns_topic.opsgenie_topic.*.arn)
+  value = {
+    for k, o in aws_sns_topic.opsgenie_topic:
+    k => o.arn
+  }
 }
 

--- a/opsgenie/sns.tf
+++ b/opsgenie/sns.tf
@@ -1,7 +1,7 @@
 resource "aws_sns_topic" "opsgenie_topic" {
-  count = length(var.teams)
+  for_each = var.teams
 
-  name = "OpsGenie-${element(keys(var.teams), count.index)}"
+  name = "OpsGenie-${each.key}"
 
   delivery_policy = <<EOF
 {
@@ -23,11 +23,11 @@ EOF
 }
 
 resource "aws_sns_topic_subscription" "opsgenie_integration" {
-  count = length(var.teams)
+  for_each = var.teams
 
-  topic_arn              = element(aws_sns_topic.opsgenie_topic.*.arn, count.index)
+  topic_arn              = aws_sns_topic.opsgenie_topic[each.key].arn
   protocol               = "https"
-  endpoint               = var.teams[element(keys(var.teams), count.index)]
+  endpoint               = each.value
   endpoint_auto_confirms = true
 }
 


### PR DESCRIPTION
## Purpose of Change
The opsgenie sns shared module worked without issue when creating an initial opsgenie team (I&A) in the DMA Shared Resources. However once there were existing opsgenie resources in the state, upon adding a second team (EACD) to the existing teams in the DMA Shared Resources, `plan` is ok but `apply` errors because the opsgenie sns output map has 2 keys (one for each team) but only 1 topic (for the first team). This indicates the output is being evaluated before the resource updates occur, and the cause is likely a [Terraform bug](https://github.com/hashicorp/terraform/issues/23365).

## What Changed
- changed from count to for_each to create the sns topic and sns subscription 
- changed from zipmap to for loop on the collection of sns topic resources (created by the for_each) to create the output map 

## Change Tested 
Tested with DMA Shared Resources sandbox locally successfully - when building the shared resources that had the error adding the second team, expect to get a TopicNotFound error on apply until you remove the existing teams and apply this for-each fix, and then will be able to re-add the second team and apply normally. Have tested that teams can be correctly added/removed once it's switched over. 