### PR TITLE
We need more subnets for competitive applications

### DIFF
--- a/private_subnet_v2/README.md
+++ b/private_subnet_v2/README.md
@@ -1,0 +1,5 @@
+# Private Subnets for us-east-2
+This module creates private subnets in us-east-2 with routing back to the internet.
+
+Since creating subnets, a route table, and the route table <-> subnet associations is rather verbose, this module serves to DRY out our most common IP allocation pattern.
+

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,5 +1,5 @@
 output "subnet_id_list" {
     value = {
-        for k, v in aws_subnet : k => v.id
+        for k, v in aws_subnet.subnets : k => v.id
     }
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,0 +1,5 @@
+output "subnet_id_list" {
+    value = {
+        for k, v in aws_subnet : k => v.id
+    }
+}

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -1,0 +1,41 @@
+# does it matter which specific CIDR block is associated with which availability zone?
+variable "CIDR_AZ_map" {
+    value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
+}
+
+resource "aws_subnet" "subnets" {
+//  this should create nothing if enabled = false, as we cannot use count and for_each
+    for_each = { for  k, v in var.CIDR_AZ_map : k => v if var.enabled }
+//    count = "${var.enabled == "true" ? 1 : 0}"
+
+    vpc_id = var.vpc_id
+    cidr_block = each.key
+    availability_zone = each.value
+
+    tags = {
+        # I think this works instead of Az1 and Az2
+        Name = "${var.label}-Pvt-${each.value}"
+    }
+}
+
+resource "aws_route_table" "route_table" {
+//  no for_each here so we can use count
+  count = var.enabled == "true" ? 1 : 0
+
+  vpc_id = var.vpc_id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = var.nat_gateway_id
+  }
+}
+
+resource "aws_route_table_association" "route_mappings" {
+  for_each = { for  k, v in aws_subnet.subnets : k => v if var.enabled }
+
+//  my IDE doesn't like each.value.id but I'm not sure why - or what the proper syntax would be
+//  the same complaint happens in outputs.tf too
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.route_table.id
+}
+

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -1,11 +1,13 @@
 # does it matter which specific CIDR block is associated with which availability zone?
-variable "CIDR_AZ_map" {
+locals {
+  CIDR_AZ_map = {
     value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
+  }
 }
 
 resource "aws_subnet" "subnets" {
 //  this should create nothing if enabled = false, as we cannot use count and for_each
-    for_each = { for  k, v in var.CIDR_AZ_map : k => v if var.enabled }
+    for_each = { for  k, v in local.CIDR_AZ_map.value : k => v if var.enabled }
 //    count = "${var.enabled == "true" ? 1 : 0}"
 
     vpc_id = var.vpc_id
@@ -34,8 +36,7 @@ resource "aws_route_table_association" "route_mappings" {
   for_each = { for  k, v in aws_subnet.subnets : k => v if var.enabled }
 
 //  my IDE doesn't like each.value.id but I'm not sure why - or what the proper syntax would be
-//  the same complaint happens in outputs.tf too
   subnet_id      = each.value.id
-  route_table_id = aws_route_table.route_table.id
+  route_table_id = aws_route_table.route_table[0].id
 }
 

--- a/private_subnet_v2/variables.tf
+++ b/private_subnet_v2/variables.tf
@@ -10,11 +10,28 @@ variable "availability_zone_list" {
   description = "list of availability zones within the VPC"
 }
 
-variable "nat_gateway_id" {
-  description = "NAT gateway ID for reaching the internet"
+variable "nat_gateway_id_list" {
+  description = "NAT gateway IDs for reaching the internet"
 }
 
-variable "label" {
+variable "transit_gateway_id" {
+  description = "Transit gateway ID used for routing traffic over the VPN. The current default is the AWS transit gateway for all accounts, but could change."
+  default = "tgw-05a25479d60902394"
+}
+
+variable "transit_gw_routes" {
+  description = "List of CIDRs that you want routed over the transit gateway instead of the public internet. The default value should cover most use-cases."
+  default = [
+    "129.105.0.0/16",
+    "165.124.0.0/16",
+    "10.101.0.0/16",
+    "10.105.0.0/16",
+    "10.120.0.0/16",
+    "10.102.0.0/15"
+  ]
+}
+
+  variable "label" {
   description = "Label for the subnet, e.g. docconv-dev"
 }
 

--- a/private_subnet_v2/variables.tf
+++ b/private_subnet_v2/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_id" {
+  description = "VPC ID in which to allocate the IPs."
+}
+
+variable "subnet_cidr_list" {
+  description = "IP blocks for multiple AZs. Minimum size is a /28"
+}
+
+variable "availability_zone_list" {
+  description = "list of availability zones within the VPC"
+}
+
+variable "nat_gateway_id" {
+  description = "NAT gateway ID for reaching the internet"
+}
+
+variable "label" {
+  description = "Label for the subnet, e.g. docconv-dev"
+}
+
+variable "enabled" {
+  description = "Whether or not to build anything at all. Useful for disabling subnet allocations in prod accounts that already have them from the pre-TF days."
+  default     = "true"
+}

--- a/private_subnet_v2/versions.tf
+++ b/private_subnet_v2/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
## Overview
This adds a new private subnet resource (wasn't sure what to call it) that can assign more than 2 subnets for more than 2 availability zones. I haven't tested it yet I just wanted to get some first impressions and see if I made any glaring errors. It should be almost identical to the existing private subnet resource just with some for_each shenanigans.

## Checklist
- [x] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [x] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [x] Variables & outputs all have descriptions