### PR TITLE
Caps

### DIFF
--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -45,7 +45,9 @@ resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
 
 //  can't zipmap these as they have values known only after apply
-  subnet_id      = aws_subnet.subnets[count.index].id
-  route_table_id = aws_route_table.route_tables[count.index].id
+//  subnet_id      = aws_subnet.subnets[count.index].id
+  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count]
+//  route_table_id = aws_route_table.route_tables[count.index].id
+  route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
 }
 


### PR DESCRIPTION
## Overview
the route mappings resource currently uses count instead of for_each to generate multiple route mappings because I don't know how to make the subnet id's and route table id's into one map. This causes the build to fail because there is no subnet[0] or subnet [1], etc. but an object with the subnets as multiple elements. My change might allow us to use count to iterate over a flattened object.

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions