### PR TITLE
route tables are tuples now

### DIFF
--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -49,8 +49,8 @@ resource "aws_route_table_association" "route_mappings" {
 
 //  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
   subnet_id = lookup(aws_subnet.subnets, "id", count.index)
-
-  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
+  route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
+//  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
   //  subnet_id      = aws_subnet.subnets[count.index].id
 //  route_table_id = aws_route_table.route_tables[count.index].id
 }


### PR DESCRIPTION
## Overview
<!-- A brief description of what the change is, how you achieved that, 
and why you are changing it. -->

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions