### PR TITLE
cleanup and changing output to list instead of map

### DIFF
--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,5 +1,5 @@
 output "subnet_id_list" {
-    value = {
-        for k, v in aws_subnet.subnets : k => v.id
-    }
+//    subnets is a map containing each subnet resource as another map (map of maps)
+//    this isolates the inner subnet map, finds the ids, and puts them in a list
+    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
 }


### PR DESCRIPTION
## Overview
cleanup and changing output to list instead of map

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions