### PR TITLE
Terraform upgrade doesn't like default values of different types

### DIFF
--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -4,7 +4,7 @@
 output "subnet_id_list" {
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
     value = tolist([
-      for subnet in keys(aws_subnet.subnets) : [
+      for subnet in aws_subnet.subnets : [
           lookup(subnet, "id", 0)
       ]
     ])

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,5 +1,5 @@
 output "subnet_id_list" {
-    value = {
-        for k, v in aws_subnet.subnets : k => v.id
-    }
+//    subnets is a map containing each subnet resource as another map (map of maps)
+//    this isolates the inner subnet map, finds the ids, and puts them in a list
+    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -2,10 +2,5 @@
 //    this isolates the inner subnet map, finds the ids, and puts them in a list
 
 output "subnet_id_list" {
-//    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
-    value = tolist([
-      for subnet in aws_subnet.subnets : [
-          lookup(subnet, "id", 0)
-      ]
-    ])
+    value = tolist([ for subnet in aws_subnet.subnets : lookup(subnet, "id", 0)])
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -5,9 +5,7 @@ output "subnet_id_list" {
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
     value = tolist([
       for subnet in keys(aws_subnet.subnets) : [
-        for map in aws_subnet.subnets[subnet] : [
           lookup(map, "id", 0)
-        ]
       ]
     ])
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,6 +1,6 @@
 //    subnets is a map containing each subnet resource as another map (map of maps)
 //    this isolates the inner subnet map, finds the ids, and puts them in a list
-locals {
+variable "subnet_id_list" {
     subnet_id_list = flatten([
     for subnet in keys(aws_subnet.subnets) : [
       for id in aws_subnet.subnets[subnet] : [
@@ -13,5 +13,5 @@ locals {
 output "subnet_id_list" {
 
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
-    value = local.subnet_id_list
+    value = var.subnet_id_list
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -5,7 +5,7 @@ output "subnet_id_list" {
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
     value = tolist([
       for subnet in keys(aws_subnet.subnets) : [
-          lookup(map, "id", 0)
+          lookup(subnet, "id", 0)
       ]
     ])
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -3,11 +3,11 @@
 
 output "subnet_id_list" {
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
-    value = tolist(flatten([
+    value = tolist([
       for subnet in keys(aws_subnet.subnets) : [
         for map in aws_subnet.subnets[subnet] : [
           lookup(map, "id", 0)
         ]
       ]
-    ]))
+    ])
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,17 +1,13 @@
 //    subnets is a map containing each subnet resource as another map (map of maps)
 //    this isolates the inner subnet map, finds the ids, and puts them in a list
-variable "subnet_id_list" {
-    subnet_id_list = flatten([
-    for subnet in keys(aws_subnet.subnets) : [
-      for id in aws_subnet.subnets[subnet] : [
-        id
+
+output "subnet_id_list" {
+//    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
+    value = flatten([
+      for subnet in keys(aws_subnet.subnets) : [
+        for id in aws_subnet.subnets[subnet] : [
+          id
         ]
       ]
     ])
-}
-
-output "subnet_id_list" {
-
-//    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
-    value = var.subnet_id_list
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -1,5 +1,17 @@
-output "subnet_id_list" {
 //    subnets is a map containing each subnet resource as another map (map of maps)
 //    this isolates the inner subnet map, finds the ids, and puts them in a list
-    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
+locals {
+    subnet_id_list = flatten([
+    for subnet in keys(aws_subnet.subnets) : [
+      for id in aws_subnet.subnets[subnet] : [
+        id
+        ]
+      ]
+    ])
+}
+
+output "subnet_id_list" {
+
+//    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
+    value = local.subnet_id_list
 }

--- a/private_subnet_v2/outputs.tf
+++ b/private_subnet_v2/outputs.tf
@@ -3,11 +3,11 @@
 
 output "subnet_id_list" {
 //    value = tolist(lookup(values(aws_subnet.subnets), "id", 0))
-    value = flatten([
+    value = tolist(flatten([
       for subnet in keys(aws_subnet.subnets) : [
-        for id in aws_subnet.subnets[subnet] : [
-          id
+        for map in aws_subnet.subnets[subnet] : [
+          lookup(map, "id", 0)
         ]
       ]
-    ])
+    ]))
 }

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -22,15 +22,16 @@ resource "aws_subnet" "subnets" {
 }
 
 resource "aws_route_table" "route_tables" {
-//  count = var.enabled == "true" ? 1 : 0
+  count = var.enabled == "true" ? length(local.NAT_Gateway_set) : 0
 //  for_each = toset(var.nat_gateway_id_list)
-  for_each = local.NAT_Gateway_set
+//  for_each = local.NAT_Gateway_set
 
   vpc_id = var.vpc_id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = each.key
+//    nat_gateway_id = each.key
+    nat_gateway_id = local.NAT_Gateway_set[count.index]
   }
 
   dynamic "route" {

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -42,9 +42,11 @@ resource "aws_route_table" "route_tables" {
 }
 
 resource "aws_route_table_association" "route_mappings" {
-  count = var.enabled ? length(aws_subnet.subnets) : 0
+  count = var.enabled ? length(var.subnet_cidr_list) : 0
 
-  subnet_id      = aws_subnet.subnets[count.index].id
-  route_table_id = aws_route_table.route_tables[count.index].id
+  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
+  route_table_id = lookup(element(keys(aws_route_table.route_tables), count.index), "id", "NO ROUTE TABLE ID HERE")
+//  subnet_id      = aws_subnet.subnets[count.index].id
+//  route_table_id = aws_route_table.route_tables[count.index].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -45,7 +45,7 @@ resource "aws_route_table_association" "route_mappings" {
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = values(lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index))
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -43,8 +43,8 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
-//  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
-//  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
+  //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
+  //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
   subnet_id = values(lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index))
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -3,6 +3,7 @@ locals {
   CIDR_AZ_map = {
     value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
   }
+  NAT_Gateway_set = toset(var.nat_gateway_id_list)
 }
 
 resource "aws_subnet" "subnets" {
@@ -22,8 +23,8 @@ resource "aws_subnet" "subnets" {
 
 resource "aws_route_table" "route_tables" {
 //  count = var.enabled == "true" ? 1 : 0
-//  for_each = var.nat_gateway_id_list
-  for_each = var.nat_gateway_id_list
+//  for_each = toset(var.nat_gateway_id_list)
+  for_each = local.NAT_Gateway_set
 
   vpc_id = var.vpc_id
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -48,7 +48,7 @@ resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
 //  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
-  subnet_id = lookup(aws_subnet.subnets, "id", count.index)
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 //  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
   //  subnet_id      = aws_subnet.subnets[count.index].id

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -49,8 +49,8 @@ resource "aws_route_table_association" "route_mappings" {
 
 //  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
   subnet_id = lookup(aws_subnet.subnets, "id", count.index)
-
-  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
+  route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
+//  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
   //  subnet_id      = aws_subnet.subnets[count.index].id
 //  route_table_id = aws_route_table.route_tables[count.index].id
 }

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -44,19 +44,19 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
 
-  dynamic "subnet_id" {
-    for_each = aws_subnet.subnets
-    content {
-      subnet_id = each.value.id
-    }
-  }
+  # dynamic "subnet_id" {
+  #   for_each = aws_subnet.subnets
+  #   content {
+  #     subnet_id = each.value.id
+  #   }
+  # }
 
-  dynamic "route_table_id" {
-    for_each = aws_route_table.route_tables
-    content {
-      route_table_id = each.value.id
-    }
-  }
+  # dynamic "route_table_id" {
+  #   for_each = aws_route_table.route_tables
+  #   content {
+  #     route_table_id = each.value.id
+  #   }
+  # }
 
 //  can't zipmap these as they have values known only after apply
 //  subnet_id      = aws_subnet.subnets[count.index].id

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -3,7 +3,7 @@ locals {
   CIDR_AZ_map = {
     value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
   }
-  NAT_Gateway_set = toset(var.nat_gateway_id_list)
+  NAT_Gateway_list = tolist(var.nat_gateway_id_list)
 }
 
 resource "aws_subnet" "subnets" {
@@ -22,7 +22,7 @@ resource "aws_subnet" "subnets" {
 }
 
 resource "aws_route_table" "route_tables" {
-  count = var.enabled == "true" ? length(local.NAT_Gateway_set) : 0
+  count = var.enabled == "true" ? length(var.nat_gateway_id_list) : 0
 //  for_each = toset(var.nat_gateway_id_list)
 //  for_each = local.NAT_Gateway_set
 
@@ -31,7 +31,7 @@ resource "aws_route_table" "route_tables" {
   route {
     cidr_block     = "0.0.0.0/0"
 //    nat_gateway_id = each.key
-    nat_gateway_id = local.NAT_Gateway_set[count.index]
+    nat_gateway_id = var.nat_gateway_id_list[count.index]
   }
 
   dynamic "route" {

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -22,7 +22,8 @@ resource "aws_subnet" "subnets" {
 
 resource "aws_route_table" "route_tables" {
 //  count = var.enabled == "true" ? 1 : 0
-  for_each = toset(var.nat_gateway_id_list)
+//  for_each = var.nat_gateway_id_list
+  for_each = var.nat_gateway_id_list
 
   vpc_id = var.vpc_id
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -45,7 +45,9 @@ resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
 
 //  can't zipmap these as they have values known only after apply
-  subnet_id      = aws_subnet.subnets[count.index].id
-  route_table_id = aws_route_table.route_tables[count.index].id
+//  subnet_id      = aws_subnet.subnets[count.index].id
+  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count]
+//  route_table_id = aws_route_table.route_tables[count.index].id
+  route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -43,8 +43,8 @@ resource "aws_route_table" "route_tables" {
 
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
-  
-  subnet_id      = aws_subnet.subnets[*].id
-  route_table_id = aws_route_table.route_tables[*].id
+
+  subnet_id      = aws_subnet.subnets[count.index].id
+  route_table_id = aws_route_table.route_tables[count.index].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -43,27 +43,8 @@ resource "aws_route_table" "route_tables" {
 
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
-
-  # dynamic "subnet_id" {
-  #   for_each = aws_subnet.subnets
-  #   content {
-  #     subnet_id = each.value.id
-  #   }
-  # }
-
-  # dynamic "route_table_id" {
-  #   for_each = aws_route_table.route_tables
-  #   content {
-  #     route_table_id = each.value.id
-  #   }
-  # }
-
-//  can't zipmap these as they have values known only after apply
-//  subnet_id      = aws_subnet.subnets[count.index].id
-  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count.index].id
-  # subnet_id      = flatten([aws_subnet.subnets])[count].id
-//  route_table_id = aws_route_table.route_tables[count.index].id
-  # route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
-  route_table_id = flatten([for id in aws_route_table.route_tables : {id = id}])[count.index].id
+  
+  subnet_id      = aws_subnet.subnets[*].id
+  route_table_id = aws_route_table.route_tables[*].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -60,10 +60,10 @@ resource "aws_route_table_association" "route_mappings" {
 
 //  can't zipmap these as they have values known only after apply
 //  subnet_id      = aws_subnet.subnets[count.index].id
-  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count].id
+  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count.index].id
   # subnet_id      = flatten([aws_subnet.subnets])[count].id
 //  route_table_id = aws_route_table.route_tables[count.index].id
   # route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
-  route_table_id = flatten([for id in aws_route_table.route_tables : {id = id}])[count].id
+  route_table_id = flatten([for id in aws_route_table.route_tables : {id = id}])[count.index].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -44,10 +44,26 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(aws_subnet.subnets) : 0
 
+  dynamic "subnet_id" {
+    for_each = aws_subnet.subnets
+    content {
+      subnet_id = each.value.id
+    }
+  }
+
+  dynamic "route_table_id" {
+    for_each = aws_route_table.route_tables
+    content {
+      route_table_id = each.value.id
+    }
+  }
+
 //  can't zipmap these as they have values known only after apply
 //  subnet_id      = aws_subnet.subnets[count.index].id
-  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count]
+  subnet_id      = flatten([for id in aws_subnet.subnets : {subnet_id = id}])[count].id
+  # subnet_id      = flatten([aws_subnet.subnets])[count].id
 //  route_table_id = aws_route_table.route_tables[count.index].id
-  route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
+  # route_table_id = flatten([for id in aws_route_table.route_tables : {route_table_id = id}])[count]
+  route_table_id = flatten([for id in aws_route_table.route_tables : {id = id}])[count].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -44,9 +44,11 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
-  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
-  route_table_id = lookup(element(keys(aws_route_table.route_tables), count.index), "id", "NO ROUTE TABLE ID HERE")
-//  subnet_id      = aws_subnet.subnets[count.index].id
+//  subnet_id = lookup(element(keys(aws_subnet.subnets), count.index), "id", "NO SUBNET ID HERE")
+  subnet_id = lookup(aws_subnet.subnets, "id", count.index)
+
+  route_table_id = lookup(aws_route_table.route_tables, "id", count.index)
+  //  subnet_id      = aws_subnet.subnets[count.index].id
 //  route_table_id = aws_route_table.route_tables[count.index].id
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -42,10 +42,10 @@ resource "aws_route_table" "route_tables" {
 
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
-
+  
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index)
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], map(object)), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }
 


### PR DESCRIPTION
## Overview
Before, a function that returns a map, i.e. lookup(), was fine with returning something else as a default if the lookup fails, now it wants to return a default of the same type that it would return if it didn't fail... maybe

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions