### PR TITLE
changed default type to a map

### DIFF
--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -44,6 +44,7 @@ resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
   subnet_id = aws_subnet.subnets[count.index].id
+  subnet_id = {for subnet in aws_subnets.subnets : subnet.id}
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -52,7 +52,7 @@ resource "aws_route_table_association" "route_mappings" {
   
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], var.Default), "id", count.index)
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], local.Default), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -43,7 +43,7 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
-  subnet_id = aws_subnet.subnets[count.index].id
+  # subnet_id = aws_subnet.subnets[count.index].id
   subnet_id = {for subnet in aws_subnets.subnets : subnet.id}
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -46,7 +46,7 @@ resource "aws_route_table_association" "route_mappings" {
   # subnet_id = aws_subnet.subnets[count.index].id
 
   # the for loop returns a list of ids, we use the current count to access the index of the id we want 
-  subnet_id = element([for subnet in aws_subnets.subnets : subnet.id], count.index)
+  subnet_id = element([for subnet in aws_subnets.subnet : subnet.id], count.index)
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -46,7 +46,7 @@ resource "aws_route_table_association" "route_mappings" {
   # subnet_id = aws_subnet.subnets[count.index].id
 
   # the for loop returns a list of ids, we use the current count to access the index of the id we want 
-  subnet_id = {for subnet in aws_subnets.subnets : element(subnet_id, count.index) }
+  subnet_id = [for subnet in aws_subnets.subnets : element(subnet_id, count.index) ]
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -46,7 +46,7 @@ resource "aws_route_table_association" "route_mappings" {
   # subnet_id = aws_subnet.subnets[count.index].id
 
   # the for loop returns a list of ids, we use the current count to access the index of the id we want 
-  subnet_id = element([for subnet in aws_subnets.subnet : subnet.id], count.index)
+  subnet_id = element([for subnet in aws_subnet.subnets : subnet.id], count.index)
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -5,7 +5,11 @@ locals {
   }
   NAT_Gateway_list = tolist(var.nat_gateway_id_list)
   Default = {
-    "key" = "value"
+    "key": "value",
+    vpc_id: "you shouldn't get here",
+    cidr_block: "the default should never run",
+    availability_zone: "nowhere"
+
   }
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -43,7 +43,7 @@ resource "aws_route_table" "route_tables" {
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
-  subnet_id = [ for subnet in aws_subnet.subnets : lookup(subnet, "id", 0)]
+  subnet_id = aws_subnet.subnets[count.index].id
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -44,7 +44,9 @@ resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
 
   # subnet_id = aws_subnet.subnets[count.index].id
-  subnet_id = {for subnet in aws_subnets.subnets : subnet.id}
+
+  # the for loop returns a list of ids, we use the current count to access the index of the id we want 
+  subnet_id = {for subnet in aws_subnets.subnets : element(subnet_id, count.index) }
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -4,6 +4,9 @@ locals {
     value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
   }
   NAT_Gateway_list = tolist(var.nat_gateway_id_list)
+  Default = {
+    "key" = "value"
+  }
 }
 
 resource "aws_subnet" "subnets" {
@@ -45,7 +48,7 @@ resource "aws_route_table_association" "route_mappings" {
   
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], map(object)), "id", count.index)
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], var.Default), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -46,7 +46,7 @@ resource "aws_route_table_association" "route_mappings" {
   # subnet_id = aws_subnet.subnets[count.index].id
 
   # the for loop returns a list of ids, we use the current count to access the index of the id we want 
-  subnet_id = [for subnet in aws_subnets.subnets : element(subnet_id, count.index) ]
+  subnet_id = element([for subnet in aws_subnets.subnets : subnet.id], count.index)
 
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -4,14 +4,6 @@ locals {
     value = zipmap(var.subnet_cidr_list, var.availability_zone_list)
   }
   NAT_Gateway_list = tolist(var.nat_gateway_id_list)
-  Default = object({
-    vpc_id: string,
-    cidr_block: string,
-    availability_zone: string
-    tags: object({
-      Name: string
-    })
-  })
 }
 
 resource "aws_subnet" "subnets" {
@@ -50,12 +42,14 @@ resource "aws_route_table" "route_tables" {
 
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
-  
+
+  subnet_id = [ for subnet in aws_subnet.subnets : lookup(subnet, "id", 0)]
+
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = lookup(
-    lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], local.Default),
-     "id", count.index)
-  route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
+  # subnet_id = lookup(
+  #   lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], local.Default),
+  #    "id", count.index)
+  route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", 0)
 }
 

--- a/private_subnet_v2/subnets.tf
+++ b/private_subnet_v2/subnets.tf
@@ -42,10 +42,10 @@ resource "aws_route_table" "route_tables" {
 
 resource "aws_route_table_association" "route_mappings" {
   count = var.enabled ? length(var.subnet_cidr_list) : 0
-
+  
   //  this monstrosity takes the map of map of subnets, finds the subnet map corresponding to count.index, and isolates its id
   //  to visualize: lookup({{map_one}, {map_two}}, map_one, default) gets us to map_one = {key:value} so we do another lookup to get the value of the the key "id"
-  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], count.index), "id", count.index)
+  subnet_id = lookup(lookup(aws_subnet.subnets, keys(aws_subnet.subnets)[count.index], map(object)), "id", count.index)
   route_table_id = lookup(element(aws_route_table.route_tables, count.index), "id", count.index)
 }
 

--- a/private_subnet_v2/variables.tf
+++ b/private_subnet_v2/variables.tf
@@ -4,14 +4,20 @@ variable "vpc_id" {
 
 variable "subnet_cidr_list" {
   description = "IP blocks for multiple AZs. Minimum size is a /28"
+  type = list
+  default = []
 }
 
 variable "availability_zone_list" {
   description = "list of availability zones within the VPC"
+  type = list
+  default = []
 }
 
 variable "nat_gateway_id_list" {
   description = "NAT gateway IDs for reaching the internet"
+  type = list
+  default = []
 }
 
 variable "transit_gateway_id" {


### PR DESCRIPTION
## Overview
Before, a function that returns a map, i.e. lookup(), was fine with returning something else as a default if the lookup fails, now it wants to return a default of the same type that it would return if it didn't fail... maybe

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions