### PR TITLE
Update s3_log_bucket.tf

### DIFF
--- a/alb/s3_log_bucket.tf
+++ b/alb/s3_log_bucket.tf
@@ -1,10 +1,15 @@
 resource "aws_s3_bucket" "alb_logs" {
   bucket = "${var.account_label}-alb-logs"
-  acl    = "private"
 
   tags = {
     SharedResource = true
   }
+}
+
+
+resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
+  bucket = aws_s3_bucket.alb_logs.id
+  acl    = "private"
 }
 
 # Needed for the ALB -> S3 policy, so the special AWS-controlled accounts


### PR DESCRIPTION
New version of AWS/Terraform breaks putting the ACL list directly on the bucket.  This fixes that

## Overview
<!-- A brief description of what the change is, how you achieved that, 
and why you are changing it. -->

## Checklist
- [ ] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [ ] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [ ] Variables & outputs all have descriptions