### PR TITLE
API Service Registry: AWS Provider Update

### DIFF
--- a/entapp_certificate/provider.tf
+++ b/entapp_certificate/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "3.58.0"
+      version = ">= 3.58.0"
     }
   }
 }


### PR DESCRIPTION
## Overview
<!-- A brief description of what the change is, how you achieved that, 
and why you are changing it. -->
To address and move forward with the [Github Actions migration to Node16](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) for the API Service Registry, I'm adding `>=` before the aws provider version for the entapp_certificate used by the ASR. This should allow the ASR to be upgraded to node16. 

--- 
I checked the validity of the change for the ASR by replacing the `tf-v1` reference with this feature branch `entapp-cert-provider`:
![image](https://github.com/NIT-Administrative-Systems/AS-Common-AWS-Modules/assets/17802293/804155f3-0c86-4460-9edc-fc74a818dbe4)


## Checklist
- [x] `terraform validate` <=0.11.x returns no errors (except maybe some vars w/out values)
- [x] In a new module, the [provider version](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions) is frozen
- [x] Variables & outputs all have descriptions